### PR TITLE
Add fixtures and results utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # FootyComp
+
+A minimal FastAPI application scaffolding for a football score prediction game. It includes:
+
+- SQLAlchemy models for users, fixtures, picks, results and joker usage.
+- Odds to points mapping with seed and lookup utilities.
+- Helper modules for ingesting fixtures and recording match results.
+- Basic tests demonstrating database interactions.
+
+Run tests and lint checks with:
+
+```bash
+ruff check .
+pytest -q
+```

--- a/app/fixtures.py
+++ b/app/fixtures.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Iterable
+
+from sqlalchemy.orm import Session
+
+from .models import Fixture
+
+
+WeekendDays = {5, 6}  # Saturday=5, Sunday=6
+
+
+def filter_weekend_fixtures(fixtures: Iterable[dict]) -> list[dict]:
+    """Return only fixtures played on Saturday or Sunday."""
+    weekend = []
+    for f in fixtures:
+        kickoff = f.get("kickoff")
+        if isinstance(kickoff, datetime) and kickoff.weekday() in WeekendDays:
+            weekend.append(f)
+    return weekend
+
+
+def ingest_fixtures(db: Session, fixtures: Iterable[dict]) -> None:
+    """Store fixtures in the database if not already present."""
+    for data in fixtures:
+        home = data["home_team"]
+        away = data["away_team"]
+        odds = data["odds"]
+        exists = (
+            db.query(Fixture)
+            .filter_by(home_team=home, away_team=away, odds=odds)
+            .first()
+        )
+        if not exists:
+            db.add(Fixture(home_team=home, away_team=away, odds=odds))
+    db.commit()

--- a/app/models.py
+++ b/app/models.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from sqlalchemy import Integer, String, Column, ForeignKey
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String
 from sqlalchemy.orm import relationship
+from datetime import datetime
 
 from .db import Base
 
@@ -15,6 +16,7 @@ class User(Base):
     role = Column(String, default="user")
 
     picks = relationship("Pick", back_populates="user")
+    jokers = relationship("Joker", back_populates="user")
 
 
 class Fixture(Base):
@@ -44,3 +46,26 @@ class OddsMapping(Base):
     id = Column(Integer, primary_key=True)
     odds = Column(String, nullable=False, unique=True)
     points = Column(Integer, nullable=False)
+
+
+class Result(Base):
+    __tablename__ = "results"
+
+    id = Column(Integer, primary_key=True)
+    fixture_id = Column(Integer, ForeignKey("fixtures.id"), unique=True)
+    home_score = Column(Integer, nullable=False)
+    away_score = Column(Integer, nullable=False)
+
+    fixture = relationship("Fixture")
+
+
+class Joker(Base):
+    __tablename__ = "jokers"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id"))
+    pick_id = Column(Integer, ForeignKey("picks.id"))
+    used_at = Column(DateTime, default=datetime.utcnow)
+
+    user = relationship("User", back_populates="jokers")
+    pick = relationship("Pick")

--- a/app/results.py
+++ b/app/results.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from .models import Result
+
+
+def record_result(db: Session, fixture_id: int, home_score: int, away_score: int) -> None:
+    """Insert or update a fixture result."""
+    result = db.query(Result).filter_by(fixture_id=fixture_id).first()
+    if not result:
+        result = Result(
+            fixture_id=fixture_id, home_score=home_score, away_score=away_score
+        )
+        db.add(result)
+    else:
+        result.home_score = home_score
+        result.away_score = away_score
+    db.commit()
+
+
+def is_home_win(result: Result) -> bool:
+    """Return True if the home team won."""
+    return result.home_score > result.away_score

--- a/app/tests/test_fixtures_results.py
+++ b/app/tests/test_fixtures_results.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from datetime import datetime
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.db import Base
+from app.models import Fixture
+from app.fixtures import filter_weekend_fixtures, ingest_fixtures
+from app.results import record_result, is_home_win
+
+
+SessionLocal = None
+
+
+def setup_module(module):
+    engine = create_engine("sqlite:///:memory:")
+    TestingSessionLocal = sessionmaker(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    module.engine = engine
+    module.SessionLocal = TestingSessionLocal
+
+
+def test_filter_weekend_fixtures():
+    fixtures = [
+        {"kickoff": datetime(2024, 6, 22), "home_team": "A", "away_team": "B", "odds": "1/1"},
+        {"kickoff": datetime(2024, 6, 24), "home_team": "C", "away_team": "D", "odds": "2/1"},
+    ]
+    weekend = filter_weekend_fixtures(fixtures)
+    assert len(weekend) == 1
+    assert weekend[0]["home_team"] == "A"
+
+
+def test_ingest_and_record_result():
+    db = SessionLocal()
+    fixtures = [
+        {"home_team": "TeamA", "away_team": "TeamB", "odds": "2/1", "kickoff": datetime(2024, 6, 22)},
+        {"home_team": "TeamA", "away_team": "TeamB", "odds": "2/1", "kickoff": datetime(2024, 6, 22)},
+    ]
+    ingest_fixtures(db, fixtures)
+    assert db.query(Fixture).count() == 1
+
+    fixture_id = db.query(Fixture.id).first()[0]
+    record_result(db, fixture_id, 2, 1)
+    from app.models import Result
+    res = db.query(Result).filter_by(fixture_id=fixture_id).first()
+    assert res is not None
+    assert is_home_win(res) is True
+    # Update result
+    record_result(db, fixture_id, 0, 0)
+    res = db.query(Result).filter_by(fixture_id=fixture_id).first()
+    assert res.home_score == 0
+    db.close()


### PR DESCRIPTION
## Summary
- flesh out README
- expand SQLAlchemy models to include Result and Joker
- add helpers for weekend fixture ingestion and result recording
- add unit tests for fixtures and result utilities

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685669065b4c832bb5e7473038697425