### PR TITLE
Add API for user picks

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5,11 +5,13 @@ from sqlalchemy.orm import Session
 
 from .db import Base, engine, get_db
 from .odds import seed_default_mapping, get_points_for_odds
+from .routers.picks import router as picks_router
 
 
 Base.metadata.create_all(bind=engine)
 
 app = FastAPI(title="FootyComp")
+app.include_router(picks_router)
 
 
 @app.on_event("startup")

--- a/app/routers/picks.py
+++ b/app/routers/picks.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from ..db import get_db
+from ..models import Pick
+
+
+class PickRead(BaseModel):
+    id: int
+    fixture_id: int
+    joker: int
+
+    class Config:
+        from_attributes = True
+
+
+router = APIRouter()
+
+
+@router.get("/users/{user_id}/picks", response_model=list[PickRead])
+def get_user_picks(user_id: int, db: Session = Depends(get_db)) -> list[Pick]:
+    """Return all picks for the given user."""
+    return db.query(Pick).filter_by(user_id=user_id).all()

--- a/app/tests/test_api_picks.py
+++ b/app/tests/test_api_picks.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.db import Base, get_db
+from app.main import app
+from app.models import User, Fixture, Pick
+
+SessionLocal = None
+engine = None
+
+
+def setup_module(module):
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    TestingSessionLocal = sessionmaker(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    module.engine = engine
+    module.SessionLocal = TestingSessionLocal
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+
+
+def teardown_module(module):
+    app.dependency_overrides.clear()
+
+
+def test_get_user_picks():
+    db = SessionLocal()
+    user = User(email="foo@example.com", hashed_password="x")
+    fixture = Fixture(home_team="A", away_team="B", odds="1/1")
+    db.add_all([user, fixture])
+    db.commit()
+    user_id = user.id
+    fixture_id = fixture.id
+    pick = Pick(user_id=user_id, fixture_id=fixture_id, joker=0)
+    db.add(pick)
+    db.commit()
+    db.close()
+
+    client = TestClient(app)
+    resp = client.get(f"/users/{user_id}/picks")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+    assert len(data) == 1
+    assert data[0]["fixture_id"] == fixture_id

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pydantic
 psycopg2-binary
 ruff
 pytest
+httpx


### PR DESCRIPTION
## Summary
- create picks router and implement `/users/{user_id}/picks` endpoint
- register router in FastAPI app
- test new endpoint with FastAPI TestClient
- include `httpx` in requirements

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685669fc1900832ba8c2b4362bb825e2