### PR TITLE
Add odds management API

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -6,12 +6,14 @@ from sqlalchemy.orm import Session
 from .db import Base, engine, get_db
 from .odds import seed_default_mapping, get_points_for_odds
 from .routers.picks import router as picks_router
+from .routers.odds import router as odds_router
 
 
 Base.metadata.create_all(bind=engine)
 
 app = FastAPI(title="FootyComp")
 app.include_router(picks_router)
+app.include_router(odds_router)
 
 
 @app.on_event("startup")

--- a/app/routers/odds.py
+++ b/app/routers/odds.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from ..db import get_db
+from ..models import OddsMapping
+
+
+class OddsRead(BaseModel):
+    odds: str
+    points: int
+
+    class Config:
+        from_attributes = True
+
+
+class OddsUpdate(BaseModel):
+    points: int
+
+
+router = APIRouter()
+
+
+@router.get("/odds", response_model=list[OddsRead])
+def list_odds(db: Session = Depends(get_db)) -> list[OddsMapping]:
+    """Return all odds-to-points mappings."""
+    return db.query(OddsMapping).all()
+
+
+@router.post(
+    "/odds",
+    status_code=status.HTTP_201_CREATED,
+    response_model=OddsRead,
+)
+def create_odds(mapping: OddsRead, db: Session = Depends(get_db)) -> OddsMapping:
+    """Create a new odds mapping."""
+    exists = db.query(OddsMapping).filter_by(odds=mapping.odds).first()
+    if exists:
+        raise HTTPException(status_code=409, detail="Odds already mapped")
+    record = OddsMapping(odds=mapping.odds, points=mapping.points)
+    db.add(record)
+    db.commit()
+    db.refresh(record)
+    return record
+
+
+@router.put("/odds/{odds:path}", response_model=OddsRead)
+def update_odds(
+    odds: str, data: OddsUpdate, db: Session = Depends(get_db)
+) -> OddsMapping:
+    """Update points for an odds mapping."""
+    record = db.query(OddsMapping).filter_by(odds=odds).first()
+    if not record:
+        raise HTTPException(status_code=404, detail="Mapping not found")
+    record.points = data.points
+    db.commit()
+    db.refresh(record)
+    return record

--- a/app/tests/test_api_odds.py
+++ b/app/tests/test_api_odds.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.db import Base, get_db
+from app.main import app
+
+SessionLocal = None
+engine = None
+
+
+def setup_module(module):
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    TestingSessionLocal = sessionmaker(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    module.engine = engine
+    module.SessionLocal = TestingSessionLocal
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+
+
+def teardown_module(module):
+    app.dependency_overrides.clear()
+
+
+def test_create_and_update_odds():
+    client = TestClient(app)
+    resp = client.post("/odds", json={"odds": "1/1", "points": 5})
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["odds"] == "1/1"
+    assert data["points"] == 5
+
+    resp = client.put("/odds/1%2F1", json={"points": 10})
+    assert resp.status_code == 200
+    assert resp.json()["points"] == 10
+
+    resp = client.get("/odds")
+    assert resp.status_code == 200
+    items = resp.json()
+    assert len(items) == 1
+    assert items[0]["points"] == 10


### PR DESCRIPTION
## Summary
- wire up new odds router in main app
- implement CRUD endpoints for odds mapping
- add integration tests for the new odds API

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68566b0c93d8832ba386127df0756e17