### PR TITLE
docs: add agent onboarding guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# Agent Onboarding Guide
+
+Welcome to **FootyComp**. This document explains how to work within the repository without disrupting existing functionality or look and feel.
+
+## Repository Docs
+- **requirements.txt** lists all runtime, linting and testing dependencies. Install or update them with `pip install -r requirements.txt` and modify the file when new packages are added.
+- **docs/tech_spec.md** describes architecture, database models and API contracts. Review it before making structural changes.
+- **docs/user_stories/** contains numbered markdown files that drive feature development. Reference the appropriate story in your commit message and keep the numbering sequence.
+
+## Stack & Structure
+- Python 3 with [FastAPI](https://fastapi.tiangolo.com/) for the web layer and SQLAlchemy for ORM.
+- Application code lives under `app/`:
+  - `models.py` defines ORM models.
+  - `routers/` holds FastAPI routers; add new endpoints in their own router modules.
+  - `tests/` contains pytest tests mirroring the package structure.
+- Follow existing design patterns and SOLID principles: keep modules small, use dependency injection via `Depends`, and reuse helpers from `db.py`, `fixtures.py` and `results.py` when relevant.
+
+## Environment & Secrets
+- `THE_ODDS_API_KEY` (repository secret `The-odds-api-key`) authorizes requests to the external odds API service. Retrieve it with `os.getenv("THE_ODDS_API_KEY")` and never hard-code values. In tests, mock the call or supply a dummy value.
+
+## Development Workflow
+1. For any behavior change, write or update tests in `app/tests/`.
+2. Run `ruff check .` for linting and `pytest -q` for tests before committing.
+3. Ensure UI or API changes preserve current look and feel and do not break existing contracts.
+
+## Deployment
+- Local development server: `uvicorn app.main:app --reload`.
+- Production deployment should run the same app via `uvicorn` or `gunicorn` behind a process manager with a PostgreSQL database. Update configuration details in `docs/tech_spec.md` if deployment requirements change.
+- The project deploys to [Render](https://render.com). Keep the `render.yaml` manifest synchronized with your changes—add services, environment variables, or build commands as needed and commit updates alongside code.
+
+Following these guidelines will help keep the project maintainable and consistent.


### PR DESCRIPTION
## Summary
- add AGENTS.md with repository workflow, stack guidance, and odds API secret instructions
- note Render deployment and the need to keep `render.yaml` up to date

## Testing
- no tests run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_688f0438e8e4832b9aba9b884086a2d7