### PR TITLE
feat: add coupon endpoint for weekly fixtures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# Agent Onboarding Guide
+
+Welcome to **FootyComp**. This document explains how to work within the repository without disrupting existing functionality or look and feel.
+
+## Repository Docs
+- **requirements.txt** lists all runtime, linting and testing dependencies. Install or update them with `pip install -r requirements.txt` and modify the file when new packages are added.
+- **docs/tech_spec.md** describes architecture, database models and API contracts. Review it before making structural changes.
+- **docs/user_stories/** contains numbered markdown files that drive feature development. Reference the appropriate story in your commit message and keep the numbering sequence. Before coding, expand the target story with a **Technical Implementation** section outlining the specific tasks you'll perform.
+
+## Stack & Structure
+- Python 3 with [FastAPI](https://fastapi.tiangolo.com/) for the web layer and SQLAlchemy for ORM.
+- Application code lives under `app/`:
+  - `models.py` defines ORM models.
+  - `routers/` holds FastAPI routers; add new endpoints in their own router modules.
+  - `tests/` contains pytest tests mirroring the package structure.
+- Follow existing design patterns and SOLID principles: keep modules small, use dependency injection via `Depends`, and reuse helpers from `db.py`, `fixtures.py` and `results.py` when relevant.
+
+## Environment & Secrets
+- `THE_ODDS_API_KEY` (repository secret `The-odds-api-key`) authorizes requests to the external odds API service. Retrieve it with `os.getenv("THE_ODDS_API_KEY")` and never hard-code values. In tests, mock the call or supply a dummy value.
+
+## Competition Flow
+- Weekly coupons carry `season` and `week` numbers.
+- Weeks increment sequentially (1, 2, 3, ...).
+- Start week numbering over at 1 when a new season begins.
+
+## Development Workflow
+1. For any behavior change, write or update tests in `app/tests/`.
+2. Run `ruff check .` for linting and `pytest -q` for tests before committing.
+3. Ensure UI or API changes preserve current look and feel and do not break existing contracts.
+
+## Deployment
+- Local development server: `uvicorn app.main:app --reload`.
+- Production deployment should run the same app via `uvicorn` or `gunicorn` behind a process manager with a PostgreSQL database. Update configuration details in `docs/tech_spec.md` if deployment requirements change.
+- The project deploys to [Render](https://render.com). Keep the `render.yaml` manifest synchronized with your changes—add services, environment variables, or build commands as needed and commit updates alongside code.
+
+Following these guidelines will help keep the project maintainable and consistent.

--- a/app/fixtures.py
+++ b/app/fixtures.py
@@ -27,11 +27,27 @@ def ingest_fixtures(db: Session, fixtures: Iterable[dict]) -> None:
         home = data["home_team"]
         away = data["away_team"]
         odds = data["odds"]
+        season = data.get("season", 1)
+        week = data.get("week", 1)
         exists = (
             db.query(Fixture)
-            .filter_by(home_team=home, away_team=away, odds=odds)
+            .filter_by(
+                home_team=home,
+                away_team=away,
+                odds=odds,
+                season=season,
+                week=week,
+            )
             .first()
         )
         if not exists:
-            db.add(Fixture(home_team=home, away_team=away, odds=odds))
+            db.add(
+                Fixture(
+                    home_team=home,
+                    away_team=away,
+                    odds=odds,
+                    season=season,
+                    week=week,
+                )
+            )
     db.commit()

--- a/app/main.py
+++ b/app/main.py
@@ -7,6 +7,7 @@ from .db import Base, engine, get_db
 from .odds import seed_default_mapping, get_points_for_odds
 from .routers.picks import router as picks_router
 from .routers.odds import router as odds_router
+from .routers.coupon import router as coupon_router
 
 
 Base.metadata.create_all(bind=engine)
@@ -14,6 +15,7 @@ Base.metadata.create_all(bind=engine)
 app = FastAPI(title="FootyComp")
 app.include_router(picks_router)
 app.include_router(odds_router)
+app.include_router(coupon_router)
 
 
 @app.on_event("startup")

--- a/app/models.py
+++ b/app/models.py
@@ -23,6 +23,8 @@ class Fixture(Base):
     __tablename__ = "fixtures"
 
     id = Column(Integer, primary_key=True)
+    season = Column(Integer, default=1, nullable=False)
+    week = Column(Integer, default=1, nullable=False)
     home_team = Column(String, nullable=False)
     away_team = Column(String, nullable=False)
     odds = Column(String, nullable=False)

--- a/app/routers/coupon.py
+++ b/app/routers/coupon.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+from sqlalchemy import func
+from pydantic import BaseModel
+
+from ..db import get_db
+from ..models import Fixture
+
+
+class FixtureRead(BaseModel):
+    id: int
+    season: int
+    week: int
+    home_team: str
+    away_team: str
+    odds: str
+
+    class Config:
+        from_attributes = True
+
+
+router = APIRouter()
+
+
+@router.get("/coupon", response_model=list[FixtureRead])
+def read_coupon(
+    season: int | None = None,
+    week: int | None = None,
+    db: Session = Depends(get_db),
+) -> list[Fixture]:
+    """Return fixtures for the requested season and week.
+
+    Defaults to the latest week of the latest season.
+    """
+    if season is None:
+        season = db.query(func.max(Fixture.season)).scalar() or 1
+    query = db.query(Fixture).filter(Fixture.season == season)
+
+    if week is None:
+        week = (
+            db.query(func.max(Fixture.week))
+            .filter(Fixture.season == season)
+            .scalar()
+            or 1
+        )
+    query = query.filter(Fixture.week == week)
+    return query.all()

--- a/app/tests/test_api_coupon.py
+++ b/app/tests/test_api_coupon.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.db import Base, get_db
+from app.main import app
+from app.models import Fixture
+
+SessionLocal = None
+engine = None
+
+
+def setup_module(module):
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    TestingSessionLocal = sessionmaker(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    module.engine = engine
+    module.SessionLocal = TestingSessionLocal
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+
+
+def teardown_module(module):
+    app.dependency_overrides.clear()
+
+
+def test_read_coupon_defaults_to_latest_week_and_season():
+    db = SessionLocal()
+    db.add_all(
+        [
+            Fixture(
+                home_team="Team A",
+                away_team="Team B",
+                odds="1/1",
+                season=1,
+                week=1,
+            ),
+            Fixture(
+                home_team="Team C",
+                away_team="Team D",
+                odds="2/1",
+                season=1,
+                week=2,
+            ),
+            Fixture(
+                home_team="Team E",
+                away_team="Team F",
+                odds="3/1",
+                season=2,
+                week=1,
+            ),
+        ]
+    )
+    db.commit()
+    db.close()
+
+    client = TestClient(app)
+    resp = client.get("/coupon")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["home_team"] == "Team E"
+    assert data[0]["season"] == 2
+    assert data[0]["week"] == 1
+
+    resp = client.get("/coupon", params={"season": 1})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["home_team"] == "Team C"
+    assert data[0]["week"] == 2
+
+    resp = client.get("/coupon", params={"season": 1, "week": 1})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["home_team"] == "Team A"

--- a/docs/tech_spec.md
+++ b/docs/tech_spec.md
@@ -39,6 +39,8 @@ Each service runs in its own Docker container and is deployed as a Render servic
 - FastAPI application exposing REST endpoints:
   - Player management and authentication
   - Weekly team selection with optional joker flag
+  - Weekly coupon retrieval
+    - Coupons are grouped by `season` and `week`; week numbers increment sequentially and reset to 1 each new season
   - Points allocation boundary management
   - Odds provider selection
   - League table retrieval

--- a/docs/user_stories/01_player_views_coupon.md
+++ b/docs/user_stories/01_player_views_coupon.md
@@ -5,3 +5,12 @@ As a player, I want to see the weekly match coupon so that I know which fixtures
 ## Acceptance Criteria
 - Coupon lists all matches for the week with selection options
 - Coupon is accessible via the web app and Facebook post
+- Week numbers increment sequentially (1, 2, 3, ...)
+- A new season resets the week number to 1
+
+## Technical Implementation
+- Create an API endpoint `GET /coupon` that returns fixtures for the requested `season` and `week`, defaulting to the latest week of the latest season.
+- Expose the endpoint through a dedicated router and include it in the FastAPI app.
+- Represent fixtures with a Pydantic model containing `id`, `season`, `week`, `home_team`, `away_team`, and `odds` fields.
+- Store `season` and `week` alongside fixtures in the database.
+- Add tests verifying the endpoint returns fixtures for the correct season and week.


### PR DESCRIPTION
## Summary
- document technical tasks for User Story 01 and update contributor guidelines
- add `/coupon` API endpoint and integrate router into FastAPI app
- support season/week tracking for coupons with docs and tests

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f0438e8e4832b9aba9b884086a2d7